### PR TITLE
support(eslint): Adds support to EsLint using Red Style Guide

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = { 
+    "extends": "eslint-config-red",
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "sourceType": "module",
+    }
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,0 @@
-module.exports = { 
-    "extends": "eslint-config-red",
-    "parserOptions": {
-        "ecmaVersion": 6,
-        "sourceType": "module",
-    }
-};

--- a/package.json
+++ b/package.json
@@ -23,7 +23,13 @@
   },
   "devDependencies": {
     "eslint": "^6.5.1",
-    "eslint-config-red": "^1.4.1",
-    "eslint-plugin-import": "^2.18.2"
+    "eslint-config-red": "^1.4.1"
+  },
+  "eslintConfig": {
+    "extends": "eslint-config-red",
+    "parserOptions": {
+      "ecmaVersion": 6,
+      "sourceType": "module"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,10 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/GrosSacASac/randomsac.git"
+  },
+  "devDependencies": {
+    "eslint": "^6.5.1",
+    "eslint-config-red": "^1.4.1",
+    "eslint-plugin-import": "^2.18.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Random functions",
   "module": "random.js",
   "scripts": {
-    "test": "echo see tests"
+    "test": "echo see tests",
+    "eslint": "./node_modules/.bin/eslint random.js"
   },
   "files": [
     "random.js",


### PR DESCRIPTION
# What I did
- Added 3 development dependencies (`eslint`, `eslint-config-red` and `eslint-plugin-import `)
  - The third one sometimes needed with `import` and `export` problems
- Added `.eslintrc.js` to configure EsLint to use Red Style Guide 
- Added another script `eslint` for easy access

# How I did it
- ran `npm install eslint eslint-config-red eslint-plugin-import --save-dev`
- ensured everything is fine by running `./node_modules/.bin/eslint random.js`
- ensured the same result by running `npm run eslint`

# How to verify it
- run `npm install`
- run `./node_modules/.bin/eslint random.js` to check and/or run `npm run eslint`

#  A picture of a cute animal
![animal-1850186_640](https://user-images.githubusercontent.com/87614/66126455-5cde8500-e5e1-11e9-8711-fa94d562cef9.jpg)

Fixes #2 